### PR TITLE
queryItem bugfix

### DIFF
--- a/src/intentDelegates/queryItem.js
+++ b/src/intentDelegates/queryItem.js
@@ -10,7 +10,7 @@ module.exports = function(handler, table) {
                     range: slots.Item.value
                     })
             .then(function(resp) {
-                if (resp != undefined && resp.quantity != 0) {
+                if (resp != undefined && resp.quantity != undefined && resp.quantity != 0) {
                   handler.emit(':tell', handler.t('QUANTITY_NONZERO', resp.quantity, slots.Item.value.toLowerCase()));
                 }
                 else {

--- a/src/test/queryItemQuantityTest.js
+++ b/src/test/queryItemQuantityTest.js
@@ -132,6 +132,37 @@ describe("Testing QueryItem intent", function() {
         })
     })
 
+    describe("valid input with item with no quantity", function() {
+        var speechResponse = null
+        var speechError = null
+        var currentQuantity = Math.floor((Math.random() * (100 - 2)) + 2);
+
+        before(function(done){
+            var input = JSON.parse(JSON.stringify(blankInput))
+            input.request.intent.slots.Item.value = testItemName
+            const testItem = {userId: testUserId, itemName: testItemName};
+            executor.insertItemThenExecute(stewardItems, testItem, input, function(err, resp) {
+                if (err) { console.log(err); speechError = err}
+                else { speechResponse = resp }
+                done()
+            })
+        })
+
+        it('should not have errored',function() {
+            expect(speechError).to.be.null
+        })
+
+        it("should have an answer with quantity", function() {
+            var expected = sprintf(strings.QUANTITY_ZERO, testItemName)
+            expect(speechResponse.response.outputSpeech.ssml).to.be.string(ssmlWrap(expected))
+        })
+
+        it("should end the alexa session", function() {
+            expect(speechResponse.response.shouldEndSession).not.to.be.null
+            expect(speechResponse.response.shouldEndSession).to.be.true
+        })
+    })
+
     describe("valid input with no item in table", function() {
         var speechResponse = null
         var speechError = null
@@ -153,8 +184,8 @@ describe("Testing QueryItem intent", function() {
         })
 
         it("should have a regular message with quantity 0", function() {
-          var expected = sprintf(strings.QUANTITY_ZERO, testItemName)
-          expect(speechResponse.response.outputSpeech.ssml).to.be.string(ssmlWrap(expected))
+            var expected = sprintf(strings.QUANTITY_ZERO, testItemName)
+            expect(speechResponse.response.outputSpeech.ssml).to.be.string(ssmlWrap(expected))
         })
 
         it("should end the alexa session", function() {

--- a/src/test/queryItemQuantityTest.js
+++ b/src/test/queryItemQuantityTest.js
@@ -135,7 +135,6 @@ describe("Testing QueryItem intent", function() {
     describe("valid input with item with no quantity", function() {
         var speechResponse = null
         var speechError = null
-        var currentQuantity = Math.floor((Math.random() * (100 - 2)) + 2);
 
         before(function(done){
             var input = JSON.parse(JSON.stringify(blankInput))


### PR DESCRIPTION
found error where if the quantity field did not exist, the non-zero quantity case was entered

fixed by adding field check to the intent